### PR TITLE
Update AWS SDK Version to 1.11.82

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://github.com/awslabs/dynamodb-import-export-tool.git</url>
     </scm>
     <properties>
-        <aws.java.sdk.version>1.10.10</aws.java.sdk.version>
+        <aws.java.sdk.version>1.11.82</aws.java.sdk.version>
         <powermock.version>1.6.2</powermock.version>
         <jcommander.version>1.48</jcommander.version>
         <guava.version>15.0</guava.version>


### PR DESCRIPTION
The current AWS SDK version in the POM will fail to provide credentials when run inside a container in ECS